### PR TITLE
Fix README defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ camera.postDelayed(new Runnable() {
 |---------|------|-------------|
 |[`ckFacing`](#ckfacing)|[`back`](#back) [`front`](#front)|`back`|
 |[`ckFlash`](#ckflash)|[`off`](#off) [`on`](#on) [`auto`](#auto)|`off`|
-|[`ckFocus`](#ckfocus)|[`off`](#off-1) [`continuous`](#continuous) [`tap`](#tap)|`continuous`|
+|[`ckFocus`](#ckfocus)|[`off`](#off-1) [`continuous`](#continuous) [`tap`](#tap)|`off`|
 |[`ckMethod`](#ckmethod)|[`standard`](#standard) [`still`](#still) [`speed`](#speed)|`standard`|
 |[`ckZoom`](#ckzoom)|[`off`](#off-2) [`pinch`](#pinch)|`off`|
 |[`ckCropOutput`](#ckcropoutput)|[`true`](#true) [`false`](#false)|`false`|


### PR DESCRIPTION
Default ckFocus is `off`, not `continuous`: [CameraKit Defaults](https://github.com/flurgle/CameraKit-Android/blob/master/camerakit/src/main/java/com/flurgle/camerakit/CameraKit.java#L42)