### PR TITLE
Fixed landscape rotation issues

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -354,9 +354,10 @@ public class Camera1 extends CameraImpl {
     }
 
     private void adjustCameraParameters() {
+        boolean invertPreviewSizes = mDisplayOrientation%180 != 0;
         mPreview.setTruePreviewSize(
-                getPreviewResolution().getWidth(),
-                getPreviewResolution().getHeight()
+                invertPreviewSizes? getPreviewResolution().getHeight() : getPreviewResolution().getWidth(),
+                invertPreviewSizes? getPreviewResolution().getWidth() : getPreviewResolution().getHeight()
         );
 
         mCameraParameters.setPreviewSize(

--- a/camerakit/src/main/api16/com/flurgle/camerakit/ProcessStillTask.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/ProcessStillTask.java
@@ -7,13 +7,13 @@ class ProcessStillTask implements Runnable {
 
     private byte[] data;
     private Camera camera;
-    private Camera.CameraInfo cameraInfo;
+    private int rotation;
     private OnStillProcessedListener onStillProcessedListener;
 
-    public ProcessStillTask(byte[] data, Camera camera, Camera.CameraInfo cameraInfo, OnStillProcessedListener onStillProcessedListener) {
+    public ProcessStillTask(byte[] data, Camera camera, int rotation, OnStillProcessedListener onStillProcessedListener) {
         this.data = data;
         this.camera = camera;
-        this.cameraInfo = cameraInfo;
+        this.rotation = rotation;
         this.onStillProcessedListener = onStillProcessedListener;
     }
 
@@ -22,7 +22,6 @@ class ProcessStillTask implements Runnable {
         Camera.Parameters parameters = camera.getParameters();
         int width = parameters.getPreviewSize().width;
         int height = parameters.getPreviewSize().height;
-        int rotation = cameraInfo.orientation;
         byte[] rotatedData = new Rotation(data, width, height, rotation).getYuv();
 
         int postWidth;

--- a/camerakit/src/main/base/com/flurgle/camerakit/TextureViewPreview.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/TextureViewPreview.java
@@ -2,7 +2,6 @@ package com.flurgle.camerakit;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
 import android.view.TextureView;
@@ -24,14 +23,12 @@ class TextureViewPreview extends PreviewImpl {
             @Override
             public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
                 setSize(width, height);
-                configureTransform();
                 dispatchSurfaceChanged();
             }
 
             @Override
             public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
                 setSize(width, height);
-                configureTransform();
                 dispatchSurfaceChanged();
                 setTruePreviewSize(mTrueWidth, mTrueHeight);
             }
@@ -71,7 +68,6 @@ class TextureViewPreview extends PreviewImpl {
     @Override
     void setDisplayOrientation(int displayOrientation) {
         mDisplayOrientation = displayOrientation;
-        configureTransform();
     }
 
     @Override
@@ -96,39 +92,6 @@ class TextureViewPreview extends PreviewImpl {
         if (mTextureView.getSurfaceTexture() != null) {
             mTextureView.getSurfaceTexture().setDefaultBufferSize(width, height);
         }
-    }
-
-    void configureTransform() {
-        Matrix matrix = new Matrix();
-        if (mDisplayOrientation % 180 == 90) {
-            final int width = getWidth();
-            final int height = getHeight();
-            // Rotate the camera preview when the screen is landscape.
-            matrix.setPolyToPoly(
-                    new float[]{
-                            0.f, 0.f, // top left
-                            width, 0.f, // top right
-                            0.f, height, // bottom left
-                            width, height, // bottom right
-                    }, 0,
-                    mDisplayOrientation == 90 ?
-                            // Clockwise
-                            new float[]{
-                                    0.f, height, // top left
-                                    0.f, 0.f, // top right
-                                    width, height, // bottom left
-                                    width, 0.f, // bottom right
-                            } : // mDisplayOrientation == 270
-                            // Counter-clockwise
-                            new float[]{
-                                    width, 0.f, // top left
-                                    width, height, // top right
-                                    0.f, 0.f, // bottom left
-                                    0.f, height, // bottom right
-                            }, 0,
-                    4);
-        }
-        mTextureView.setTransform(matrix);
     }
 
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
 
         <activity
             android:name=".MainActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This fixes the orientation problems discussed on #19 (at least on my device - Nexus 6 with android 7.0) and might also fix #38

I removed the matrix transformation on the preview, as it was doing the same thing as `mCamera.setDisplayOrientation(calculateCameraRotation(mDisplayOrientation));` from `Camera1.java` - resulting in double-rotation in landscape.

If you wish to test, you need to remove `android:screenOrientation="portrait"` from the Manifest

The removed matrix transformation from `TextureViewPreview` seems like a lot of work and I imagine it covered a corner case or something - so if anyone knows why it was there, please let me know so I can bring it back for those specific cases (maybe certain APIs or manufacturers need it).

