### PR TITLE
Ignore tap-to-focus if not supported

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -449,7 +449,9 @@ public class Camera1 extends CameraImpl {
                         Camera.Parameters parameters = mCamera.getParameters();
                         if (parameters.getMaxNumMeteringAreas() > 0) {
                             Rect rect = calculateFocusArea(event.getX(), event.getY());
-
+                            if(!parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
+                                return false; //cannot autoFocus
+                            }
                             parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
                             List<Camera.Area> meteringAreas = new ArrayList<>();
                             meteringAreas.add(new Camera.Area(rect, getFocusMeteringAreaWeight()));


### PR DESCRIPTION
This fixes the issue where app crashes if user taps to focus but camera does not support it.

Sample crash log:

> ...
> /? E/Camera2-Parameters: set: Requested focus mode "auto" is not available: fixed focus lens
> /com.flurgle.camerakit.demo E/InputEventReceiver: Exception dispatching input event.
> /com.flurgle.camerakit.demo E/MessageQueue-JNI: Exception in MessageQueue callback: handleReceiveCallback
> /com.flurgle.camerakit.demo E/MessageQueue-JNI: java.lang.RuntimeException: setParameters failed
> ...
