### PR TITLE
Fixing focus for many Samsung and Sony Devices

### DIFF
--- a/camerakit/src/main/types/com/flurgle/camerakit/Focus.java
+++ b/camerakit/src/main/types/com/flurgle/camerakit/Focus.java
@@ -8,8 +8,9 @@ import java.lang.annotation.RetentionPolicy;
 import static com.flurgle.camerakit.CameraKit.Constants.FOCUS_TAP;
 import static com.flurgle.camerakit.CameraKit.Constants.FOCUS_OFF;
 import static com.flurgle.camerakit.CameraKit.Constants.FOCUS_CONTINUOUS;
+import static com.flurgle.camerakit.CameraKit.Constants.FOCUS_TAP_WITH_MARKER;
 
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({FOCUS_CONTINUOUS, FOCUS_TAP, FOCUS_OFF})
+@IntDef({FOCUS_CONTINUOUS, FOCUS_TAP, FOCUS_OFF, FOCUS_TAP_WITH_MARKER})
 public @interface Focus {
 }


### PR DESCRIPTION
**Why is this specially important?** because simply parameters.getMaxNumMeteringAreas() on devices like Samsung(s) e.g. *S6*, *S7*  is always returning 0, and accordingly manual focus never works on these devices.