### PR TITLE
added video quality option for QVGA

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -443,11 +443,19 @@ public class Camera1 extends CameraImpl {
     private CamcorderProfile getCamcorderProfile(@VideoQuality int videoQuality) {
         CamcorderProfile camcorderProfile = null;
         switch (videoQuality) {
+            case CameraKit.Constants.VIDEO_QUALITY_QVGA:
+                if (CamcorderProfile.hasProfile(mCameraId, CamcorderProfile.QUALITY_QVGA)) {
+                    camcorderProfile = CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_QVGA);
+                } else {
+                    return getCamcorderProfile(CameraKit.Constants.VIDEO_QUALITY_LOWEST);
+                }
+                break;
+
             case CameraKit.Constants.VIDEO_QUALITY_480P:
                 if (CamcorderProfile.hasProfile(mCameraId, CamcorderProfile.QUALITY_480P)) {
                     camcorderProfile = CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_480P);
                 } else {
-                    return getCamcorderProfile(CameraKit.Constants.VIDEO_QUALITY_LOWEST);
+                    return getCamcorderProfile(CameraKit.Constants.VIDEO_QUALITY_QVGA);
                 }
                 break;
 

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraKit.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraKit.java
@@ -44,6 +44,7 @@ public class CameraKit {
         public static final int VIDEO_QUALITY_2160P = 3;
         public static final int VIDEO_QUALITY_HIGHEST = 4;
         public static final int VIDEO_QUALITY_LOWEST = 5;
+        public static final int VIDEO_QUALITY_QVGA = 6;
 
     }
 

--- a/camerakit/src/main/res/values/attrs.xml
+++ b/camerakit/src/main/res/values/attrs.xml
@@ -46,6 +46,7 @@
         <attr name="ckJpegQuality" format="integer" />
 
         <attr name="ckVideoQuality" format="enum">
+            <enum name="maxQVGA" value="6" />
             <enum name="max480p" value="0" />
             <enum name="max720p" value="1" />
             <enum name="max1080p" value="2" />

--- a/camerakit/src/main/types/com/flurgle/camerakit/VideoQuality.java
+++ b/camerakit/src/main/types/com/flurgle/camerakit/VideoQuality.java
@@ -11,8 +11,9 @@ import static com.flurgle.camerakit.CameraKit.Constants.VIDEO_QUALITY_480P;
 import static com.flurgle.camerakit.CameraKit.Constants.VIDEO_QUALITY_720P;
 import static com.flurgle.camerakit.CameraKit.Constants.VIDEO_QUALITY_HIGHEST;
 import static com.flurgle.camerakit.CameraKit.Constants.VIDEO_QUALITY_LOWEST;
+import static com.flurgle.camerakit.CameraKit.Constants.VIDEO_QUALITY_QVGA;
 
 @Retention(RetentionPolicy.SOURCE)
-@IntDef({VIDEO_QUALITY_480P, VIDEO_QUALITY_720P, VIDEO_QUALITY_1080P, VIDEO_QUALITY_2160P, VIDEO_QUALITY_HIGHEST, VIDEO_QUALITY_LOWEST})
+@IntDef({VIDEO_QUALITY_QVGA, VIDEO_QUALITY_480P, VIDEO_QUALITY_720P, VIDEO_QUALITY_1080P, VIDEO_QUALITY_2160P, VIDEO_QUALITY_HIGHEST, VIDEO_QUALITY_LOWEST})
 public @interface VideoQuality {
 }


### PR DESCRIPTION
Since 480p was to high of a resolution for my needs, and LOWEST (depending on the device) was too low, I added support for the QVGA resolution.