### PR TITLE
Crash fixed, when camera initialization called very frequently

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -7,8 +7,9 @@ import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
 import android.os.Build;
 import android.os.Handler;
-import android.util.Log;
+import android.os.HandlerThread;
 import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.View;
@@ -17,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -49,6 +49,7 @@ public class Camera1 extends CameraImpl {
     private File mVideoFile;
     private Camera.AutoFocusCallback mAutofocusCallback;
     private boolean capturingImage = false;
+    private CameraHandlerThread mThread = null;
 
     private int mDisplayOrientation;
 
@@ -364,7 +365,7 @@ public class Camera1 extends CameraImpl {
             releaseCamera();
         }
 
-        mCamera = Camera.open(mCameraId);
+        newOpenCamera();
         mCameraParameters = mCamera.getParameters();
 
         collectCameraProperties();
@@ -372,6 +373,25 @@ public class Camera1 extends CameraImpl {
         mCamera.setDisplayOrientation(calculatePreviewRotation());
 
         mCameraListener.onCameraOpened();
+    }
+
+    private void newOpenCamera() {
+        if (mThread == null) {
+            mThread = new CameraHandlerThread();
+        }
+
+        synchronized (mThread) {
+            mThread.openCamera();
+        }
+    }
+
+    private void oldOpenCamera() {
+        try {
+            mCamera = Camera.open(mCameraId);
+        }
+        catch (RuntimeException e) {
+            Log.e(TAG, "failed to open front camera");
+        }
     }
 
     private void setupPreview() {
@@ -684,4 +704,33 @@ public class Camera1 extends CameraImpl {
         }
     }
 
+    private class CameraHandlerThread extends HandlerThread {
+        Handler mHandler = null;
+
+        CameraHandlerThread() {
+            super("CameraHandlerThread");
+            start();
+            mHandler = new Handler(getLooper());
+        }
+
+        synchronized void notifyCameraOpened() {
+            notify();
+        }
+
+        void openCamera() {
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    oldOpenCamera();
+                    notifyCameraOpened();
+                }
+            });
+            try {
+                wait();
+            }
+            catch (InterruptedException e) {
+                Log.w(TAG, "wait was interrupted");
+            }
+        }
+    }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "25.0.3"
     defaultConfig {
         applicationId "com.flurgle.camerakit.demo"
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 4
         versionName "1.0.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile project(':camerakit')
-    compile 'com.android.support:appcompat-v7:25.2.0'
-    compile 'com.jakewharton:butterknife:8.4.0'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.jakewharton:butterknife:8.5.1'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 }

--- a/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity implements View.OnLayoutChan
     ViewGroup parent;
 
     @BindView(R.id.camera)
-    CameraView camera;
+    CameraView camera;;
 
     // Capture Mode:
 


### PR DESCRIPTION
If fragments switch very frequently, camera methods in fragment lifecycles methods onPause and onResume makes RuntimeException. My commits fixed this crash, by integration ThreadHandler in Camera1